### PR TITLE
Handle null value that marks a tombstone

### DIFF
--- a/src/main/scala/com/moleike/kafka/streams/avro/generic/KafkaAvroDeserializerS.scala
+++ b/src/main/scala/com/moleike/kafka/streams/avro/generic/KafkaAvroDeserializerS.scala
@@ -19,7 +19,8 @@ class KafkaAvroDeserializerS[A: Encoder : Decoder : SchemaFor]
   override def configure(configs: JMap[String, _], isKey: Boolean): Unit = ()
 
   override def deserialize(topic: String, bytes: Array[Byte]): A =
-    recordFormat.from(inner.deserialize(topic, bytes).asInstanceOf[GenericRecord])
+    if (bytes == null) null.asInstanceOf[A]
+    else recordFormat.from(inner.deserialize(topic, bytes).asInstanceOf[GenericRecord])
 
   override def close(): Unit = inner.close()
 }

--- a/src/main/scala/com/moleike/kafka/streams/avro/generic/KafkaAvroSerializerS.scala
+++ b/src/main/scala/com/moleike/kafka/streams/avro/generic/KafkaAvroSerializerS.scala
@@ -18,7 +18,8 @@ class KafkaAvroSerializerS[A: Encoder : Decoder : SchemaFor]
   override def configure(configs: JMap[String, _], isKey: Boolean): Unit = ()
 
   override def serialize(topic: String, value: A): Array[Byte] =
-    inner.serialize(topic, recordFormat.to(value))
+    if (value == null) null
+    else inner.serialize(topic, recordFormat.to(value))
 
   override def close(): Unit = inner.close()
 }


### PR DESCRIPTION
Sometimes we want to encode and decode null.
We cannot replace null with None, since the Scala Kafka Streams library is a thin wrapper around the Java one, and Java expects null.